### PR TITLE
Fix NPE when invoked without arguments

### DIFF
--- a/src/com/yahoo/platform/yui/compressor/YUICompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/YUICompressor.java
@@ -106,12 +106,12 @@ public class YUICompressor {
                             }
                         }
 
-                        if (type == null || !type.equalsIgnoreCase("js") && !type.equalsIgnoreCase("css")) {
-                            usage();
-                            System.exit(1);
-                        }
-
                         in = new InputStreamReader(new FileInputStream(inputFilename), charset);
+                    }
+
+                    if (type == null || !type.equalsIgnoreCase("js") && !type.equalsIgnoreCase("css")) {
+                        usage();
+                        System.exit(1);
                     }
 
                     String outputFilename = output;


### PR DESCRIPTION
This patch fixes a NPE when yuicompressor is invoked without arguments.
