### PR TITLE
Changed CSSCompressor to not die on data strings

### DIFF
--- a/src/com/yahoo/platform/yui/compressor/CssCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/CssCompressor.java
@@ -51,9 +51,17 @@ public class CssCompressor {
 
         startIndex = 0;
         ArrayList dataStrings = new ArrayList(0);
-        // Take out data strings
+        // Take out data strings for double quotes
         while((startIndex = sb.indexOf("url(\"data:", startIndex)) >= 0) {
         	endIndex = sb.indexOf("\"", startIndex+10);
+        	if(endIndex > startIndex + 10) {
+        		dataStrings.add(sb.substring(startIndex+4, endIndex+1));
+        		sb.replace(startIndex+4, endIndex+1, "___YUICSSMIN_DATA_STRING_" + dataStrings.size() + "___");
+        	}
+        }
+        // Take out data strings for single quotes (because I am lazy)
+        while((startIndex = sb.indexOf("url('data:", startIndex)) >= 0) {
+        	endIndex = sb.indexOf("'", startIndex+10);
         	if(endIndex > startIndex + 10) {
         		dataStrings.add(sb.substring(startIndex+4, endIndex+1));
         		sb.replace(startIndex+4, endIndex+1, "___YUICSSMIN_DATA_STRING_" + dataStrings.size() + "___");


### PR DESCRIPTION
Embedded fonts are really cool, but they cause the CSS Compressor to either die or take several minutes (depending on the version).  I've added code to prestrip data strings out to make things much faster.

We use this version in production at http://nabewise.com .

For a file with 3 embedded fonts, the execution time went from 3+ minutes to well under a second.
