### PR TITLE
Parameter parsing fix (when compressing multiple files)

### DIFF
--- a/src/com/yahoo/platform/yui/compressor/YUICompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/YUICompressor.java
@@ -78,6 +78,10 @@ public class YUICompressor {
                 System.exit(1);
             }
 
+            boolean munge = parser.getOptionValue(nomungeOpt) == null;
+            boolean preserveAllSemiColons = parser.getOptionValue(preserveSemiOpt) != null;
+            boolean disableOptimizations = parser.getOptionValue(disableOptimizationsOpt) != null;
+
             String[] fileArgs = parser.getRemainingArgs();
             java.util.List files = java.util.Arrays.asList(fileArgs);
             if (files.isEmpty()) {
@@ -164,10 +168,6 @@ public class YUICompressor {
                             } else {
                                 out = new OutputStreamWriter(new FileOutputStream(outputFilename), charset);
                             }
-
-                            boolean munge = parser.getOptionValue(nomungeOpt) == null;
-                            boolean preserveAllSemiColons = parser.getOptionValue(preserveSemiOpt) != null;
-                            boolean disableOptimizations = parser.getOptionValue(disableOptimizationsOpt) != null;
 
                             compressor.compress(out, linebreakpos, munge, verbose,
                                     preserveAllSemiColons, disableOptimizations);


### PR DESCRIPTION
Parameter parsing fix, when compressing multiple files, nomunge, preserve-semi and disable-optimizations options will be valid only for the first file

You will see that the parser.getOptionValue() calls were inside the while block, but in the second cycle these calls do not return with the same value as first time.
