### PR TITLE
sync #id fix with the Java version

### DIFF
--- a/ports/js/cssmin.js
+++ b/ports/js/cssmin.js
@@ -249,6 +249,11 @@ YAHOO.compressor.cssmin = function (css, linebreakpos) {
     // which makes the filter break in IE.
     css = css.replace(/([^"'=\s])(\s*)#([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])/gi, function () {
         var group = arguments;
+        if (group[1] === '}') {
+            // Likely an ID selector. Don't touch.
+            // #AABBCC is a valid ID. IDs are case-sensitive.
+            return group[0];
+        }
         if (
             group[3].toLowerCase() === group[4].toLowerCase() &&
             group[5].toLowerCase() === group[6].toLowerCase() &&


### PR DESCRIPTION
while this fix looks like better than nothing, there are cases where the original problem might reappear, because we rely that the ID is the first thing in the selector after a }. But what if it's:
- #somethig #FFAADD
- div#BBAADD
- the first thing in the file
- following a /*! keep-me comment */
