### PR TITLE
Add preferGlobal=true to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "scripts": {
         "test": "yuitest ./nodejs_tests/tests.js"
     },
+    "preferGlobal": true,
     "licenses":[
         {
             "type" : "BSD",


### PR DESCRIPTION
Guessing that most people will just want to install & use
this as a globally available command line tool. Though I
could be wrong!
