### PR TITLE
Adding -webkit-mask-position to 0 0 swapout exceptions

### DIFF
--- a/src/com/yahoo/platform/yui/compressor/CssCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/CssCompressor.java
@@ -253,7 +253,7 @@ public class CssCompressor {
         // Replace background-position:0; with background-position:0 0;
         // same for transform-origin
         sb = new StringBuffer();
-        p = Pattern.compile("(?i)(background-position|transform-origin|webkit-transform-origin|webkit-mask-position|moz-transform-origin|o-transform-origin|ms-transform-origin):0(;|})");
+        p = Pattern.compile("(?i)(background-position|webkit-mask-position|transform-origin|webkit-transform-origin|moz-transform-origin|o-transform-origin|ms-transform-origin):0(;|})");
         m = p.matcher(css);
         while (m.find()) {
             m.appendReplacement(sb, m.group(1).toLowerCase() + ":0 0" + m.group(2));


### PR DESCRIPTION
Changing -webkit-mask-position: 0 0 to just a single 0 will result in the second parameter defaulting to 50%. This change adds webkit-mask-position to the exceptions regex.
