### PR TITLE
Fix stale link to documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
 <h2 id="quick-links">Quick Links</h2>
 <ul>
-  <li><a href="https://github.com/yui/yuicompressor/blob/master/doc/README">Documentation</a>: Detailed description of the YUI Compressor and how to use it.</li>
+  <li><a href="https://github.com/yui/yuicompressor/blob/master/README.md">Documentation</a>: Detailed description of the YUI Compressor and how to use it.</li>
   <li><a href="https://github.com/yui/yuicompressor/blob/master/doc/CHANGELOG">Release Notes</a>: Detailed change log for the YUI Compressor.</li>
   <li><a href="css.html">CSS minification</a>: Description of the CSS minification performed by the compressor.</li>
   <li><strong>License:</strong> All code specific to YUI Compressor is issued under a <a href="/yui/license.html">BSD license</a>.  YUI Compressor extends and implements code from <a href="http://www.mozilla.org/rhino/">Mozilla's Rhino project</a>.  Rhino is issued under the <a href="http://www.mozilla.org/MPL/">Mozilla Public License (MPL)</a>, and MPL applies to the Rhino source and binaries that are distributed with YUI Compressor, including Rhino modifications made by YUI Compressor. YUI Compressor also makes use of and distributes a binary of <a href="http://jargs.sourceforge.net/">JArgs</a>; the JArgs BSD license applies to this binary.</li>


### PR DESCRIPTION
/doc/README was moved to /README.md in 88584542ee4918e38bc145d3e9e9a8f86c2d78dc but url in index.html was not updated.
