### PR TITLE
Remove emails from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,3 @@ install:
 script:
     - ./tests/suite.sh
     - npm test
-notifications:
-    email:
-        - davglass@gmail.com
-        - davglass@yahoo-inc.com
-        - joeysmith@gmail.com


### PR DESCRIPTION
Remove the default email addresses from the Travis config, this will have Travis email the committer of a failed build.
