### PR TITLE
Protect a DOT token following a number

### DIFF
--- a/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
@@ -1107,7 +1107,6 @@ public class JavaScriptCompressor {
             token = consumeToken();
             symbol = token.getValue();
             currentScope = getCurrentScope();
-
             switch (token.getType()) {
                 case Token.GET:
                 case Token.SET:
@@ -1139,9 +1138,20 @@ public class JavaScriptCompressor {
                     break;
 
                 case Token.REGEXP:
-                case Token.NUMBER:
                 case Token.STRING:
                     result.append(symbol);
+                    break;
+
+                case Token.NUMBER:
+                    if (getToken(0).getType() == Token.DOT) {
+                        // calling methods on int requires a leading dot so JS doesn't
+                        // treat the method as the decimal component of a float
+                        result.append('(');
+                        result.append(symbol);
+                        result.append(')');
+                    } else {
+                        result.append(symbol);
+                    }
                     break;
 
                 case Token.ADD:

--- a/tests/issue86.js
+++ b/tests/issue86.js
@@ -1,0 +1,2 @@
+.0.toString()
+1.3.toString()

--- a/tests/issue86.js.min
+++ b/tests/issue86.js.min
@@ -1,0 +1,1 @@
+(0).toString();(1.3).toString();


### PR DESCRIPTION
When we see a Number, look-ahead one token; if we find a DOT, wrap the number in () so that the token after the DOT gets evaulated correctly
