### PR TITLE
Updating download link to the YUI Compressor releases page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
   <li><a href="https://github.com/yui/yuicompressor/blob/master/doc/CHANGELOG">Release Notes</a>: Detailed change log for the YUI Compressor.</li>
   <li><a href="css.html">CSS minification</a>: Description of the CSS minification performed by the compressor.</li>
   <li><strong>License:</strong> All code specific to YUI Compressor is issued under a <a href="/yui/license.html">BSD license</a>.  YUI Compressor extends and implements code from <a href="http://www.mozilla.org/rhino/">Mozilla's Rhino project</a>.  Rhino is issued under the <a href="http://www.mozilla.org/MPL/">Mozilla Public License (MPL)</a>, and MPL applies to the Rhino source and binaries that are distributed with YUI Compressor, including Rhino modifications made by YUI Compressor. YUI Compressor also makes use of and distributes a binary of <a href="http://jargs.sourceforge.net/">JArgs</a>; the JArgs BSD license applies to this binary.</li>
-  <li><a href="http://yuilibrary.com/downloads/#yuicompressor">Download</a>: Download the YUI Compressor.</li>
+  <li><a href="https://github.com/yui/yuicompressor/releases">Download</a>: Download the YUI Compressor.</li>
 </ul>
 
 


### PR DESCRIPTION
Please update the gh-pages with a link to the new releases page for downloads.
This fixes issue https://github.com/yui/yuicompressor/issues/82 
