### PR TITLE
Fixed regex bug with preserved token "calc"

### DIFF
--- a/src/com/yahoo/platform/yui/compressor/CssCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/CssCompressor.java
@@ -139,7 +139,7 @@ public class CssCompressor {
 
 
         css = this.preserveToken(css, "url", "(?i)url\\(\\s*([\"']?)data\\:", true, preservedTokens);
-        css = this.preserveToken(css, "calc",  "(?i)calc\\s*([\"']?)", false, preservedTokens);
+        css = this.preserveToken(css, "calc",  "(?i)calc\\(\\s*([\"']?)", false, preservedTokens);
         css = this.preserveToken(css, "progid:DXImageTransform.Microsoft.Matrix",  "(?i)progid:DXImageTransform.Microsoft.Matrix\\s*([\"']?)", false, preservedTokens);
 
 

--- a/tests/bug-preservetoken-calc.css
+++ b/tests/bug-preservetoken-calc.css
@@ -1,0 +1,8 @@
+/* test for not breaking class names with preserved tokens */
+.calculate-classname-test {
+    width: calc(10% + 100px);
+}
+
+.background-url-test {
+    content: '/foo/bar';
+}

--- a/tests/bug-preservetoken-calc.css.min
+++ b/tests/bug-preservetoken-calc.css.min
@@ -1,0 +1,1 @@
+.calculate-classname-test{width:calc(10% + 100px)}.background-url-test{content:'/foo/bar'}


### PR DESCRIPTION
I noticed class names containing ``calculator`` caused a broken stylesheet. This was related to a bug in the regular expression for preserving the ``calc()`` function's whitespaces.
I added some test files and made a hotfix for that.