### PR TITLE
Promises support

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -1970,7 +1970,18 @@ public class Parser
 
                     tt = nextToken();
                     switch (tt) {
-                    
+                      // handle promise.catch()
+                      case Token.CATCH:
+                        decompiler.addName("catch");
+                        pn = propertyName(pn, "catch", memberTypeFlags);
+                        break;
+
+                      // handle promise.finally()
+                      case Token.FINALLY:
+                    	decompiler.addName("finally");
+                    	pn = propertyName(pn, "finally", memberTypeFlags);
+                    	break;
+
                       // needed for generator.throw();
                       case Token.THROW:
                         decompiler.addName("throw");

--- a/tests/promise-catch-finally-issue203.js
+++ b/tests/promise-catch-finally-issue203.js
@@ -1,0 +1,4 @@
+var p = new Promise(resolve, reject) {};
+p.then(function(res) {})
+.catch(function(err) {})
+.finally(function() {});

--- a/tests/promise-catch-finally-issue203.js.min
+++ b/tests/promise-catch-finally-issue203.js.min
@@ -1,0 +1,1 @@
+var p=new Promise(resolve,reject){};p.then(function(a){}).catch(function(a){}).finally(function(){});


### PR DESCRIPTION
Fix for issue #203 (promise.catch() not supported) with corresponding test. Also fixes (and tests) promise.finally() as reported in comments of same issue.
