### PR TITLE
Update license year to initial year

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,6 +1,6 @@
 YUI Compressor Copyright License Agreement (BSD License)
 
-Copyright (c) 2013, Yahoo! Inc.
+Copyright (c) 2009, Yahoo! Inc.
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf , document should list its first year of publication in its copyright