### PR TITLE
Make compressors more usable from Java context

### DIFF
--- a/src/com/yahoo/platform/yui/compressor/CssCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/CssCompressor.java
@@ -30,6 +30,10 @@ public class CssCompressor {
         }
     }
 
+    public CssCompressor(String in) {
+        srcsb.append(in);
+    }
+
     /**
      * @param css - full css string
      * @param preservedToken - token to preserve
@@ -103,8 +107,7 @@ public class CssCompressor {
         return sb.toString();
     }
 
-    public void compress(Writer out, int linebreakpos)
-            throws IOException {
+    public String getCompressedCss(int linebreakpos) {
 
         Pattern p;
         Matcher m;
@@ -504,6 +507,14 @@ public class CssCompressor {
 
         // Trim the final string (for any leading or trailing white spaces)
         css = css.trim();
+
+        return css;
+    }
+
+    public void compress(Writer out, int linebreakpos)
+            throws IOException {
+
+        String css = getCompressedCss(linebreakpos);
 
         // Write the output...
         out.write(css);

--- a/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
@@ -313,8 +313,20 @@ public class JavaScriptCompressor {
         env.setLanguageVersion(Context.VERSION_1_7);
         Parser parser = new Parser(env, reporter);
         parser.parse(in, null, 1);
-        String source = parser.getEncodedSource();
+        return getTokensFromEncodedSource(parser.getEncodedSource());
+    }
 
+    private static ArrayList parse(String in, ErrorReporter reporter)
+            throws IOException, EvaluatorException {
+
+        CompilerEnvirons env = new CompilerEnvirons();
+        env.setLanguageVersion(Context.VERSION_1_7);
+        Parser parser = new Parser(env, reporter);
+        parser.parse(in, null, 1);
+        return getTokensFromEncodedSource(parser.getEncodedSource());
+    }
+
+    private static ArrayList getTokensFromEncodedSource (String source) {
         int offset = 0;
         int length = (source != null) ? source.length() : 0;
         ArrayList tokens = new ArrayList();
@@ -539,6 +551,12 @@ public class JavaScriptCompressor {
         this.logger = reporter;
         this.tokens = parse(in, reporter);
     }
+    public JavaScriptCompressor(String in, ErrorReporter reporter)
+            throws IOException, EvaluatorException {
+
+        this.logger = reporter;
+        this.tokens = parse(in, reporter);
+    }
     public void compress(Writer out, int linebreak, boolean munge, boolean verbose,
             boolean preserveAllSemiColons, boolean disableOptimizations) 
             throws IOException {
@@ -546,6 +564,17 @@ public class JavaScriptCompressor {
             disableOptimizations, false);
     }
     public void compress(Writer out, Writer mungemap, int linebreak, boolean munge, boolean verbose,
+            boolean preserveAllSemiColons, boolean disableOptimizations, boolean preserveUnknownHints)
+            throws IOException {
+
+        out.write(getCompressedCode(mungemap, linebreak, munge, verbose, preserveAllSemiColons, disableOptimizations, preserveUnknownHints));
+
+        if (mungemap != null) {
+            printMungeMapping(mungemap);
+        }
+    }
+
+    public String getCompressedCode (Writer mungemap, int linebreak, boolean munge, boolean verbose,
             boolean preserveAllSemiColons, boolean disableOptimizations, boolean preserveUnknownHints)
             throws IOException {
 
@@ -565,12 +594,8 @@ public class JavaScriptCompressor {
         mungeSymboltree();
         StringBuffer sb = printSymbolTree(linebreak, preserveAllSemiColons);
 
-        out.write(sb.toString());
-
-        if (mungemap != null) {
-            printMungeMapping(mungemap);
-        }
-    }
+		return sb.toString();
+	}
 
     private ScriptOrFnScope getCurrentScope() {
         return (ScriptOrFnScope) scopes.peek();


### PR DESCRIPTION
This makes YUICompressor more flexible for usage in other software products.
It enables the user to pass JS/CSS *Strings* instead of files to the compressors - it also enables the user to grab the minified code without having to write it to a file.

It does not impact the functionality of the compressors at all, it merely adds layer to the compressors which can act as a point of extension or can be used as is to simply retrieve the compressed JS/CSS without reading/writing it from/to a file.

All tests pass since no extra functionality is introduced. I tried my best to adopt your coding style and indentation rules and hope you think this code benefits YUICompressor :)
