### PR TITLE
Allow default named field in member expressions and improve ES5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/build_tmp
 build/yuicompressor*.jar
 .project
 .classpath
+.idea/

--- a/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
@@ -311,6 +311,7 @@ public class JavaScriptCompressor {
 
         CompilerEnvirons env = new CompilerEnvirons();
         env.setLanguageVersion(Context.VERSION_1_7);
+        env.setReservedKeywordAsIdentifier(true);
         Parser parser = new Parser(env, reporter);
         parser.parse(in, null, 1);
         String source = parser.getEncodedSource();

--- a/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
@@ -546,6 +546,12 @@ public class JavaScriptCompressor {
         compress(out, null, linebreak, munge, verbose, preserveAllSemiColons, 
             disableOptimizations, false);
     }
+
+    public void compress(Writer out, Writer mungemap, int linebreak, boolean munge, boolean verbose,
+                         boolean preserveAllSemiColons, boolean disableOptimizations) throws IOException {
+        compress(out, mungemap, linebreak, munge, verbose, preserveAllSemiColons, disableOptimizations, false);
+    }
+
     public void compress(Writer out, Writer mungemap, int linebreak, boolean munge, boolean verbose,
             boolean preserveAllSemiColons, boolean disableOptimizations, boolean preserveUnknownHints)
             throws IOException {

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -1988,6 +1988,12 @@ public class Parser
                         pn = propertyName(pn, "throw", memberTypeFlags);
                         break;
 
+                      // Handle default as field name
+                      case Token.DEFAULT:
+                        decompiler.addName("default");
+                        pn = propertyName(pn, "default", memberTypeFlags);
+                        break;
+
                       // handles: name, ns::name, ns::*, ns::[expr]
                       case Token.NAME:
                         s = ts.getString();

--- a/tests/bug-default-member.js
+++ b/tests/bug-default-member.js
@@ -1,0 +1,1 @@
+function (obj) { obj.default() }

--- a/tests/bug-default-member.js.min
+++ b/tests/bug-default-member.js.min
@@ -1,0 +1,1 @@
+function(a){a.default()};


### PR DESCRIPTION
`function (obj) { obj.default() }` causes following syntax errors without the change. This PR fixes it. Test included. Also allows reserved keywords as identifiers.

```
[ERROR] in bug-default-member.js
  1:29:missing name after . operator
[ERROR] in bug-default-member.js
  1:32:missing } after function body
[ERROR] in bug-default-member.js
  1:0:Compilation produced 2 syntax errors.
org.mozilla.javascript.EvaluatorException: Compilation produced 2 syntax errors.
	at com.yahoo.platform.yui.compressor.YUICompressor$1.runtimeError(YUICompressor.java:193)
	at org.mozilla.javascript.Parser.parse(Parser.java:396)
	at org.mozilla.javascript.Parser.parse(Parser.java:340)
	at com.yahoo.platform.yui.compressor.JavaScriptCompressor.parse(JavaScriptCompressor.java:315)
	at com.yahoo.platform.yui.compressor.JavaScriptCompressor.<init>(JavaScriptCompressor.java:540)
	at com.yahoo.platform.yui.compressor.YUICompressor.main(YUICompressor.java:168)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at com.yahoo.platform.yui.compressor.Bootstrap.main(Bootstrap.java:21)
```