### PR TITLE
Fixed syntax errors while minifying jquery-3.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/build_tmp
 build/yuicompressor*.jar
 .project
 .classpath
+/bin/

--- a/ant.properties
+++ b/ant.properties
@@ -3,6 +3,6 @@ lib.dir = lib
 doc.dir = doc
 build.dir = build
 product.name = yuicompressor
-version.number = 2.4.9-BSI-1
+version.number = 2.4.9-BSI-2
 jar.name = ${product.name}-${version.number}.jar
 dist.package.name = ${product.name}-${version.number}

--- a/ant.properties
+++ b/ant.properties
@@ -3,6 +3,6 @@ lib.dir = lib
 doc.dir = doc
 build.dir = build
 product.name = yuicompressor
-version.number = 2.4.9
+version.number = 2.4.9-BSI-1
 jar.name = ${product.name}-${version.number}.jar
 dist.package.name = ${product.name}-${version.number}

--- a/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
@@ -213,7 +213,6 @@ public class JavaScriptCompressor {
         reserved.add("enum");
         reserved.add("export");
         reserved.add("extends");
-        reserved.add("final");
         reserved.add("float");
         reserved.add("goto");
         reserved.add("implements");
@@ -221,7 +220,6 @@ public class JavaScriptCompressor {
         reserved.add("int");
         reserved.add("interface");
         reserved.add("long");
-        reserved.add("native");
         reserved.add("package");
         reserved.add("private");
         reserved.add("protected");

--- a/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/JavaScriptCompressor.java
@@ -230,7 +230,6 @@ public class JavaScriptCompressor {
         reserved.add("static");
         reserved.add("super");
         reserved.add("synchronized");
-        reserved.add("throws");
         reserved.add("transient");
         reserved.add("volatile");
         // These are not reserved, but should be taken into account

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -231,7 +231,6 @@ class TokenStream
                     if (c=='d') { X="delete";id=Id_delete; }
                     else if (c=='r') { X="return";id=Id_return; }
                     break L;
-                case 'h': X="throws";id=Id_throws; break L;
                 case 'm': X="import";id=Id_import; break L;
                 case 'o': X="double";id=Id_double; break L;
                 case 't': X="static";id=Id_static; break L;

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -142,7 +142,6 @@ class TokenStream
             Id_double        = Token.RESERVED,
             Id_enum          = Token.RESERVED,
             Id_extends       = Token.RESERVED,
-            Id_final         = Token.RESERVED,
             Id_finally       = Token.FINALLY,
             Id_float         = Token.RESERVED,
             Id_goto          = Token.RESERVED,
@@ -152,7 +151,6 @@ class TokenStream
             Id_int           = Token.RESERVED,
             Id_interface     = Token.RESERVED,
             Id_long          = Token.RESERVED,
-            Id_native        = Token.RESERVED,
             Id_package       = Token.RESERVED,
             Id_private       = Token.RESERVED,
             Id_protected     = Token.RESERVED,
@@ -215,7 +213,6 @@ class TokenStream
                 case 'l': X="false";id=Id_false; break L;
                 case 'n': c=s.charAt(0);
                     if (c=='c') { X="const";id=Id_const; }
-                    else if (c=='f') { X="final";id=Id_final; }
                     break L;
                 case 'o': c=s.charAt(0);
                     if (c=='f') { X="float";id=Id_float; }
@@ -226,7 +223,6 @@ class TokenStream
                 case 't': X="catch";id=Id_catch; break L;
                 } break L;
             case 6: switch (s.charAt(1)) {
-                case 'a': X="native";id=Id_native; break L;
                 case 'e': c=s.charAt(0);
                     if (c=='d') { X="delete";id=Id_delete; }
                     else if (c=='r') { X="return";id=Id_return; }


### PR DESCRIPTION
Problem was that jQuery 3.2.1 uses a property named 'throws', which is a
future reserved keyword in YUI compressor. With the patch the check for
the throws keyword has been removed, so the property is treated like any
other regular property.

