### PR TITLE
Issue81 fix hsl compression

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,8 +33,8 @@
                deprecation="off"
                debug="on"
                includeantruntime="false"
-	           target="1.5"
-               source="1.5">
+	           target="9"
+               source="9">
             <classpath>
                 <pathelement location="${lib.dir}/jargs-1.0.jar"/>
                 <pathelement location="${lib.dir}/rhino-1.7R2.jar"/>

--- a/src/com/yahoo/platform/yui/compressor/CssCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/CssCompressor.java
@@ -355,7 +355,7 @@ public class CssCompressor {
 
         // Replace 0(px,em,%) with 0 inside groups (e.g. -MOZ-RADIAL-GRADIENT(CENTER 45DEG, CIRCLE CLOSEST-SIDE, ORANGE 0%, RED 100%))
         // Avoid replacement within hsla(), where percents are required for `s` and `l` arguments.
-        p = Pattern.compile("(?i)(?<!hsla?)\\( ?((?:[0-9a-z-.]+[ ,])*)?(?:0?\\.)?0(?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz)");
+        p = Pattern.compile("(?i)(?<!hsla?|rgba?)\\( ?((?:[0-9a-z-.]+[ ,])*)?(?:0?\\.)?0(?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz)");
         do {
           oldCss = css;
           m = p.matcher(css);

--- a/src/com/yahoo/platform/yui/compressor/CssCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/CssCompressor.java
@@ -346,7 +346,7 @@ public class CssCompressor {
         } while (!(css.equals(oldCss)));
         
         //Replace the keyframe 100% step with 'to' which is shorter
-        p = Pattern.compile("(?i)(^|,|{) ?(?:100% ?{)");
+        p = Pattern.compile("(?i)(^|,|\\{) ?(?:100% ?\\{)");
         do {
           oldCss = css;
           m = p.matcher(css);

--- a/src/com/yahoo/platform/yui/compressor/CssCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/CssCompressor.java
@@ -338,7 +338,6 @@ public class CssCompressor {
         } while (!(css.equals(oldCss)));
         
         // We do the same with % but don't replace the 0% in keyframes
-        String oldCss;
         p = Pattern.compile("(?i)(: ?)((?:[0-9a-z-.]+ )*?)?(?:0?\\.)?0(?:%)");
         do {
           oldCss = css;

--- a/src/com/yahoo/platform/yui/compressor/CssCompressor.java
+++ b/src/com/yahoo/platform/yui/compressor/CssCompressor.java
@@ -354,7 +354,8 @@ public class CssCompressor {
         } while (!(css.equals(oldCss)));
 
         // Replace 0(px,em,%) with 0 inside groups (e.g. -MOZ-RADIAL-GRADIENT(CENTER 45DEG, CIRCLE CLOSEST-SIDE, ORANGE 0%, RED 100%))
-        p = Pattern.compile("(?i)\\( ?((?:[0-9a-z-.]+[ ,])*)?(?:0?\\.)?0(?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz)");
+        // Avoid replacement within hsla(), where percents are required for `s` and `l` arguments.
+        p = Pattern.compile("(?i)(?<!hsla?)\\( ?((?:[0-9a-z-.]+[ ,])*)?(?:0?\\.)?0(?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz)");
         do {
           oldCss = css;
           m = p.matcher(css);

--- a/tests/hsla-issue81.css.min
+++ b/tests/hsla-issue81.css.min
@@ -1,1 +1,1 @@
-.color_chip{color:hsl(27,0%,50%);background:rgba(195,198,214,0.85)}
+.color_chip{color:hsla(27,0%,50%,1);background:rgba(195,198,214,0.85)}

--- a/tests/rgb-issue81.css.FAIL
+++ b/tests/rgb-issue81.css.FAIL
@@ -1,4 +1,4 @@
 .color_chip {
-    color: color: rgb(0%, 50%, 50%);
+    color: rgb(0%, 50%, 50%);
     background: rgba(195, 198, 214, 0.85);
 }

--- a/tests/rgb-issue81.css.min
+++ b/tests/rgb-issue81.css.min
@@ -1,1 +1,1 @@
-.color_chip{color: rgb(0%, 50%, 50%);background:rgba(195,198,214,0.85)}
+.color_chip{color:rgb(0%,50%,50%);background:rgba(195,198,214,0.85)}


### PR DESCRIPTION
Fix broken handling of CSS colors specified as hsl() and rgb().

For each of those functions some arguments require the use of `%`, even if the value is zero. Do not strip percent signs from arguments in these cases.